### PR TITLE
Use passed in n variable

### DIFF
--- a/sql/pgfaceting--0.2.0.sql
+++ b/sql/pgfaceting--0.2.0.sql
@@ -585,12 +585,12 @@ BEGIN
                 GROUP BY 1, 2
                 ) x
             ) counts JOIN faceting.facet_definition fd USING (facet_id)
-        WHERE rank <= 5 AND table_id = $1
+        WHERE rank <= $2 AND table_id = $1
         ORDER BY facet_id, rank, facet_value;
     $sql$,
         faceting._qualified(tdef.schemaname, tdef.facets_table),
         facet_filter)
-    USING p_table_id;
+    USING p_table_id, n;
 END;
 $$;
 


### PR DESCRIPTION
Quick fix to use passed in value of n for facet depth in place of static value of 5 in `top_values` function.